### PR TITLE
Bug fixed: To only update its own cover image

### DIFF
--- a/src/Vimeo.js
+++ b/src/Vimeo.js
@@ -83,7 +83,7 @@ THE SOFTWARE. */
 
             _this.poster(_this.poster_);
             _this.trigger('posterchange');
-            $('.vjs-poster').css({
+            $(_this).find('.vjs-poster').css({
               'background-image': 'url(' + _this.poster_ + ')'
             });
           }


### PR DESCRIPTION
To only update its own poster while there are multiple video instances on the page.

## Before:
![before](https://user-images.githubusercontent.com/9745160/27207524-bed123d4-5282-11e7-9821-d47badff9ff8.png)


## After:
![after](https://user-images.githubusercontent.com/9745160/27207525-bed5d9d8-5282-11e7-97b6-811134c44bf4.png)

